### PR TITLE
Add 'readme' parameter to pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,6 +6,7 @@ build-backend = "setuptools.build_meta"
 name = "autoreduce_utils"
 version = "22.0.0.dev22"
 description = "Various utils for the Autoreduction service"
+readme = "README.md"
 license = { text = "GNU General Public License" }
 classifiers = ["Framework :: Django", "Programming Language :: Python :: 3"]
 dependencies = [


### PR DESCRIPTION
Add 'readme' parameter to pyproject.toml. Fingers crossed that this converts to the long_description required to push to pypi.