### PR TITLE
Switch to tox (AR-1667)

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -35,9 +35,11 @@ jobs:
         with:
           repository: "autoreduction/autoreduce-workspace"
 
+      - name: Install Tox
+        run: python -m pip install tox tox-gh-actions
+
       - name: Run unit tests
-        run: >-
-          pytest --cov=autoreduce_utils --cov-report=xml
+        run: tox -e pytest
 
       - uses: codecov/codecov-action@v3
         with:
@@ -117,7 +119,8 @@ jobs:
         with:
           repository: "autoreduction/autoreduce-workspace"
 
-      - uses: autoreduction/autoreduce-actions/code_inspection@main
-        with:
-          package_name: autoreduce_utils
-          pylint: false
+      - name: Install Tox
+        run: python -m pip install tox tox-gh-actions
+
+      - name: Run code inspection with tox
+        run: tox -e code_inspection

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
-dev = []
+dev = ["pytest==7.1.2"]
 
 [project.urls]
 "Repository" = "https://github.com/autoreduction/utils"

--- a/tox.ini
+++ b/tox.ini
@@ -13,6 +13,8 @@ python =
 [testenv]
 description =
     Common environment.
+deps =
+    setuptools < 58.0.0
 passenv = *
 setenv =
     PY_COLORS=1
@@ -24,6 +26,7 @@ description =
     Run unit tests.
 skip_install = False
 deps =
+    {[testenv]deps}
     pytest
     pytest-cov
     pytest-django

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,80 @@
+[tox]
+envlist =
+    pytest
+    pylint
+    yapf
+    vulture
+isolated_build = True
+
+[gh-actions]
+python =
+    3.8: py38
+
+[testenv]
+description =
+    Common environment.
+passenv = *
+setenv =
+    PY_COLORS=1
+extras =
+    dev
+
+[testenv:pytest]
+description =
+    Run unit tests.
+skip_install = False
+deps =
+    pytest
+    pytest-cov
+    pytest-django
+commands =
+    pytest {envsitepackagesdir}/autoreduce_utils --cov={envsitepackagesdir}/autoreduce_utils --cov-report=xml
+
+[testenv:pylint]
+description =
+    Run pylint style checks.
+skip_install = False
+setenv =
+    PYTHONPATH={envsitepackagesdir}/autoreduce_utils
+deps =
+    pylint==2.14.5
+    pylint-django==2.5.3
+commands =
+    pylint --version
+    pylint {envsitepackagesdir}/autoreduce_utils --output-format=colorized
+
+[testenv:yapf]
+description =
+    Run yapf style checks.
+skip_install = True
+deps =
+    yapf==0.32.0
+    toml
+commands =
+    yapf --version
+    yapf --parallel --diff --recursive autoreduce_utils
+
+[testenv:vulture]
+description =
+    Run vulture checks.
+skip_install = True
+deps =
+    vulture==2.5
+commands =
+    vulture --version
+    vulture --min-confidence 90 autoreduce_utils
+
+[testenv:code_inspection]
+description =
+    Run code inspection checks.
+skip_install = False
+setenv =
+    PYTHONPATH={envsitepackagesdir}/autoreduce_utils
+deps =
+    {[testenv:pylint]deps}
+    {[testenv:yapf]deps}
+    {[testenv:vulture]deps}
+commands =
+    {[testenv:pylint]commands}
+    {[testenv:yapf]commands}
+    {[testenv:vulture]commands}


### PR DESCRIPTION
- Use Tox for tests
- Add `["pytest==7.1.2"] `  as dev dependencies (required for running tests)